### PR TITLE
Making namespace matcher more relaxed so that it can match dot separa…

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function(source) {
 	});
 
 	// Grab namespace for shimming encapsulated module return value.
-	var namespace = /\{namespace\s+(\w+)/.exec(source)[1];
+	var namespace = /\{namespace\s+([^\s]+).*\}/.exec(source)[1];
 	var tempDir = path.resolve(__dirname, [
 		'soytemp', // directory prefix
 		Date.now(), // datestamp


### PR DESCRIPTION
This PR relaxes the namespace matcher so that it doesn't just match a word - it matches the text before any subsequent properties, as well as period separated namespaces. This allows for the exported value to be the final object of the namespace, i.e.

```
{namespace com.foo.bar}
```

results in `bar` being exported rather than `com`.

Now, the initial implementation may have been intentional. Regardless, this is what I figure is correct behaviour. If people think otherwise, please let me know, and perhaps we can instead just make this matcher configurable, with the existing value as the default.
